### PR TITLE
Remove '.git' extension from ProjectUrl

### DIFF
--- a/Cake.XmlConfigStructureBuilder/Cake.XmlConfigStructureBuilder.csproj
+++ b/Cake.XmlConfigStructureBuilder/Cake.XmlConfigStructureBuilder.csproj
@@ -8,7 +8,7 @@
 		<PackageVersion>1.3.1</PackageVersion>
 		<Authors>BggClr</Authors>
 		<Description>The project compiles multiple xml configs to single one using the CTT</Description>
-		<PackageProjectUrl>https://github.com/graph-uk/Cake.XmlConfigStructureBuilder.git</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/graph-uk/Cake.XmlConfigStructureBuilder</PackageProjectUrl>
 		<PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</PackageIconUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
The project URL should point to the github project, not the git repository. If desired, you can add a property called `RepositoryUrl` to your csproj for the git repo as documented [here](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target).